### PR TITLE
Updated elf loader to accept dynamic payload sizes.

### DIFF
--- a/document/en/ps5/exploit.js
+++ b/document/en/ps5/exploit.js
@@ -1306,7 +1306,9 @@ async function userland() {
 
     let OFFSET_ELF_HEADER_ENTRY         = 0x18;
     let OFFSET_ELF_HEADER_PHOFF         = 0x20;
+    let OFFSET_ELF_HEADER_SHOFF         = 0x28;
     let OFFSET_ELF_HEADER_PHNUM         = 0x38;
+    let OFFSET_ELF_HEADER_SHNUM         = 0x3C;
 
     let OFFSET_PROGRAM_HEADER_TYPE      = 0x00;
     let OFFSET_PROGRAM_HEADER_FLAGS     = 0x04;
@@ -1334,8 +1336,8 @@ async function userland() {
     let conn_addr_store                 = p.malloc(0x10);
     let conn_addr_sz_store              = p.malloc(0x4);
     let conn_ret_store                  = p.malloc(0x8);
-    let elf_store_size                  = SIZE_ELF_HEADER + (SIZE_ELF_PROGRAM_HEADER * 0x10) + 0x200000;
-    let elf_store                       = p.malloc(elf_store_size);
+    let elf_header_store_size           = SIZE_ELF_HEADER;
+    let elf_header_store                = p.malloc(elf_header_store_size);
 
     let shadow_mapping_addr = new int64(0x20100000, 0x00000009);
     let mapping_addr        = new int64(0x26100000, 0x00000009);
@@ -1351,11 +1353,30 @@ async function userland() {
 
         let conn_fd = p.read4(conn_fd_store);
 
-        // Got a connection, read all we can
-        let write_ptr = elf_store.add32(0x0);
+        // Got a connection, read 0x40 bytes to parse elf header
+        let header_write_ptr = elf_header_store.add32(0x0);
+        
+        await chain.add_syscall_ret(conn_ret_store, SYSCALL_READ, conn_fd, header_write_ptr, elf_header_store_size);
+        await chain.run();
+
+        let e_shoff = p.read8(elf_header_store.add32(OFFSET_ELF_HEADER_SHOFF)) 
+        let e_shnum = p.read2(elf_header_store.add32(OFFSET_ELF_HEADER_SHNUM));
+        var elf_file_size_total = e_shoff.add32(e_shnum * 0x40);
+
+        await log("[+] ELF Header Parsed, Total Size: " + elf_file_size_total.toString(10) + " bytes... reading file now.");
+
+        let elf_store_size = Number("0x"+elf_file_size_total.toString(10));
+        let elf_store = p.malloc(elf_store_size);
+        
+        for (var b = 0; b <= SIZE_ELF_HEADER; b += 8) {
+            p.write8(elf_store.add32(b), p.read8(elf_header_store.add32(b)));
+        }
+
+        // Now we read the rest of the file
         let total_sz = 0;
+        let write_ptr = elf_store.add32(0x0).add32(SIZE_ELF_HEADER);
         for (;;) {
-            await chain.add_syscall_ret(conn_ret_store, SYSCALL_READ, conn_fd, write_ptr, elf_store_size - total_sz);
+            await chain.add_syscall_ret(conn_ret_store, SYSCALL_READ, conn_fd, write_ptr, (elf_store_size - SIZE_ELF_HEADER) - total_sz);
             await chain.run();
 
             let conn_ret = p.read4(conn_ret_store);


### PR DESCRIPTION
The current elf loader implementation has the elf store limited at 2mb, this change allows a payload of any size to come through.

This is done under the assumption that the section header table is at the bottom of the file, and then takes the section header offset + (entry size * number). Im not sure if this is always the case, but it seems to work with all elfs I have tried so far. (with the exception of kstuff, but its a really simple fix to make it work, the section header table offset just needs to be set to the file size.)